### PR TITLE
[BOJ] G5 16928 "뱀과 사다리 게임"

### DIFF
--- a/Dongwon-Kang/BOJ_10836_여왕벌.py
+++ b/Dongwon-Kang/BOJ_10836_여왕벌.py
@@ -1,0 +1,12 @@
+M, N = map(int, input().split())
+
+worms = [1] * (2*M-1)
+for _ in range(N):
+    zero, one, two = map(int, input().split())
+    for i in range(zero, zero+one):
+        worms[i] += 1
+    for j in range(zero+one, 2*M-1):
+        worms[j] += 2
+
+for k in range(M-1, -1, -1):
+    print(*([worms[k]]+worms[M:]))

--- a/Dongwon-Kang/BOJ_16928_뱀과-사다리-게임.py
+++ b/Dongwon-Kang/BOJ_16928_뱀과-사다리-게임.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+
+N, M = map(int, input().split())
+shortcut = defaultdict(int)
+for _ in range(N+M):
+    x, y = map(int, input().split())
+    shortcut[x] = y
+
+
+res = 100//6
+def bfs():
+    global res
+    visit = [1e9]*101
+    q = [(1, 0)]
+
+    while q:
+        num, cnt = q.pop(0)
+        # print(num, cnt, q)
+
+        if cnt > res:
+            continue
+        if num >= 94:
+            res = min(res, cnt)
+            continue
+
+        for i in range(6, 0, -1):
+            if shortcut[num+i] > 0:
+                next_num = shortcut[num+i]
+            else:
+                next_num = num+i
+
+            if visit[next_num] > cnt+1:
+                visit[next_num] = cnt+1
+                q.append((next_num, cnt+1))
+
+bfs()
+print(res+1)

--- a/Dongwon-Kang/BOJ_9019_DSLR.py
+++ b/Dongwon-Kang/BOJ_9019_DSLR.py
@@ -1,0 +1,35 @@
+import sys
+from collections import deque
+
+
+def bfs(A, B):
+    register = [0]*10000
+    register[A] = 1
+    q = deque([(A, '')])
+
+    while q:
+        n, commands = q.popleft()
+
+        if n == B:
+            print(commands)
+            return
+
+        for d in ['D', 'S', 'L', 'R']:
+            if d == 'D':
+                nn = (n*2)%10000
+            elif d == 'S':
+                nn = (n-1)%10000
+            elif d == 'L':
+                nn = ((n*10)%10000) + n//1000
+            elif d == 'R':
+                nn = ((n%10)*1000) + n//10
+
+            if not register[nn]:
+                register[nn] = 1
+                q.append((nn, commands+d))
+
+
+T = int(input())
+for _ in range(T):
+    A, B = map(int, sys.stdin.readline().split())
+    bfs(A, B)


### PR DESCRIPTION
문제 링크 : https://www.acmicpc.net/problem/16928

풀이 전략 : bfs + 가지치기
- 숏컷 정보, 탐색 속도 향상 위해 dict로 구현
- bfs
    - visit 이중리스트 이용해 각 칸에 도착할때까지 주사위 굴린 횟수 저장 및 갱신
    - 숏컷이 있는 경우 숏컷 이용해 이동한 숫자 que에 push
    - 숏컷 없는 경우 다음 숫자 que에 push
- 가지치기
    - 숏컷 사용않고 6칸씩 갔을때 굴린 횟수 넘으면 탐색 종료
    - 도착한 칸 숫자가 94 이상일 경우 주사위 한번만 더 굴리면 되므로 탐색 종료

주의할 점 :
- 가지치기 이용해 시간초과 피할 것